### PR TITLE
Generate OpenAI descriptions when saving events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+TimeTracker/apikey.properties

--- a/TimeTracker/app/build.gradle
+++ b/TimeTracker/app/build.gradle
@@ -17,6 +17,8 @@ android {
         versionCode 1
         versionName "1.0"
         resValue "string", "google_maps_api_key", apikeyProperties['API_KEY']
+        def openAiKey = apikeyProperties.getProperty("OPENAI_API_KEY", "")
+        buildConfigField "String", "OPENAI_API_KEY", "\"${openAiKey}\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/TimeTracker/app/src/main/java/com/cs446/group18/timetracker/ui/EventListFragment.java
+++ b/TimeTracker/app/src/main/java/com/cs446/group18/timetracker/ui/EventListFragment.java
@@ -3,6 +3,7 @@ package com.cs446.group18.timetracker.ui;
 import android.annotation.SuppressLint;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -10,6 +11,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.GridView;
 import android.widget.LinearLayout;
@@ -36,6 +38,7 @@ import com.cs446.group18.timetracker.entity.Geolocation;
 import com.cs446.group18.timetracker.entity.TimeEntry;
 import com.cs446.group18.timetracker.utils.AbstractFactory;
 import com.cs446.group18.timetracker.utils.ConcreteFactory;
+import com.cs446.group18.timetracker.utils.OpenAIDescriptionGenerator;
 import com.cs446.group18.timetracker.vm.EventListViewModelFactory;
 import com.cs446.group18.timetracker.vm.EventViewModel;
 import com.cs446.group18.timetracker.vm.GeolocationViewModel;
@@ -96,33 +99,8 @@ public class EventListFragment extends Fragment implements EventListAdapter.OnEv
                 list.setAdapter(iconAdapter);
 
                 final EditText eventNameText = promptView.findViewById(R.id.event_name);
-                final EditText eventDescriptionText = promptView.findViewById(R.id.event_description);
                 builder.setView(promptView)
-                        .setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
-                                String eventName = eventNameText.getText().toString();
-                                String eventDescription = eventDescriptionText.getText().toString();
-                                // get selected icon
-                                int selectedIcon = iconAdapter.getSelected();
-                                try {
-                                    viewModel.insert(new Event(eventName, eventDescription, selectedIcon));
-                                    Toast.makeText(eventListView.getContext(), "Add new event: " + eventName, Toast.LENGTH_SHORT).show();
-                                } catch (Exception e) {
-                                    dialog.dismiss();
-                                    AlertDialog.Builder errorBuilder = new AlertDialog.Builder(getActivity());
-                                    errorBuilder.setPositiveButton("OK",
-                                            new DialogInterface.OnClickListener() {
-                                                public void onClick(DialogInterface dialog, int id) {
-                                                    dialog.dismiss();
-                                                }
-                                            });
-                                    errorBuilder.setTitle("Error");
-                                    errorBuilder.setMessage("Please enter a valid input");
-                                    AlertDialog error = errorBuilder.create();
-                                    error.show();
-                                }
-                            }
-                        })
+                        .setPositiveButton("OK", null)
                         .setNegativeButton("Cancel",
                                 new DialogInterface.OnClickListener() {
                                     public void onClick(DialogInterface dialog, int id) {
@@ -131,6 +109,47 @@ public class EventListFragment extends Fragment implements EventListAdapter.OnEv
                                 });
 
                 AlertDialog dialog = builder.create();
+                dialog.setOnShowListener(dialogInterface -> {
+                    final Button positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+                    positiveButton.setOnClickListener(view1 -> {
+                        String eventName = eventNameText.getText().toString().trim();
+                        if (TextUtils.isEmpty(eventName)) {
+                            eventNameText.setError(getString(R.string.error_event_name_required));
+                            return;
+                        }
+
+                        int selectedIcon = iconAdapter.getSelected();
+                        if (selectedIcon == -1 && !iconList.isEmpty()) {
+                            selectedIcon = iconList.get(0);
+                        }
+
+                        if (getContext() == null) {
+                            positiveButton.setEnabled(true);
+                            return;
+                        }
+
+                        positiveButton.setEnabled(false);
+                        Toast.makeText(getContext(), getString(R.string.toast_generating_event_description), Toast.LENGTH_SHORT).show();
+
+                        final int resolvedIcon = selectedIcon;
+                        final String finalEventName = eventName;
+                        OpenAIDescriptionGenerator.generateDescription(eventName, description -> {
+                            if (!isAdded()) {
+                                positiveButton.setEnabled(true);
+                                return;
+                            }
+
+                            Event event = new Event(finalEventName, description, resolvedIcon);
+                            viewModel.insert(event);
+
+                            if (getContext() != null) {
+                                Toast.makeText(getContext(), getString(R.string.toast_event_created, finalEventName), Toast.LENGTH_SHORT).show();
+                            }
+
+                            dialog.dismiss();
+                        });
+                    });
+                });
                 dialog.show();
             }
         });
@@ -161,37 +180,12 @@ public class EventListFragment extends Fragment implements EventListAdapter.OnEv
 
 
                     final EditText eventNameText = promptView.findViewById(R.id.event_name);
-                    final EditText eventDescriptionText = promptView.findViewById(R.id.event_description);
+                    Event existingEvent = eventListAdapter.getEventAt(viewHolder.getAdapterPosition());
+                    if (existingEvent != null) {
+                        eventNameText.setText(existingEvent.getEventName());
+                    }
                     builder.setView(promptView)
-                            .setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                                public void onClick(DialogInterface dialog, int id) {
-                                    int pos = viewHolder.getAdapterPosition();
-                                    String eventName = eventNameText.getText().toString();
-                                    String eventDescription = eventDescriptionText.getText().toString();
-                                    // get selected icon
-                                    int selectedIcon = iconAdapter.getSelected();
-                                    try {
-                                        Event event = new Event(eventName, eventDescription, selectedIcon);
-                                        event.setEventId(eventId);
-                                        viewModel.update(event);
-                                        Toast.makeText(eventListView.getContext(), "Event Update", Toast.LENGTH_SHORT).show();
-
-                                    } catch (Exception e) {
-                                        dialog.dismiss();
-                                        AlertDialog.Builder errorBuilder = new AlertDialog.Builder(getActivity());
-                                        errorBuilder.setPositiveButton("OK",
-                                                new DialogInterface.OnClickListener() {
-                                                    public void onClick(DialogInterface dialog, int id) {
-                                                        dialog.dismiss();
-                                                    }
-                                                });
-                                        errorBuilder.setTitle("Error");
-                                        errorBuilder.setMessage("Please enter a valid input");
-                                        AlertDialog error = errorBuilder.create();
-                                        error.show();
-                                    }
-                                }
-                            })
+                            .setPositiveButton("OK", null)
                             .setNegativeButton("Cancel",
                                     new DialogInterface.OnClickListener() {
                                         public void onClick(DialogInterface dialog, int id) {
@@ -210,6 +204,53 @@ public class EventListFragment extends Fragment implements EventListAdapter.OnEv
                                     });
 
                     AlertDialog dialog = builder.create();
+                    dialog.setOnShowListener(dialogInterface -> {
+                        final Button positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+                        positiveButton.setOnClickListener(view1 -> {
+                            String eventName = eventNameText.getText().toString().trim();
+                            if (TextUtils.isEmpty(eventName)) {
+                                eventNameText.setError(getString(R.string.error_event_name_required));
+                                return;
+                            }
+
+                            int selectedIcon = iconAdapter.getSelected();
+                            if (selectedIcon == -1) {
+                                Event currentEvent = eventListAdapter.getEventAt(viewHolder.getAdapterPosition());
+                                if (currentEvent != null) {
+                                    selectedIcon = currentEvent.getIcon();
+                                } else if (!iconList.isEmpty()) {
+                                    selectedIcon = iconList.get(0);
+                                }
+                            }
+
+                            if (getContext() == null) {
+                                positiveButton.setEnabled(true);
+                                return;
+                            }
+
+                            positiveButton.setEnabled(false);
+                            Toast.makeText(getContext(), getString(R.string.toast_generating_event_description), Toast.LENGTH_SHORT).show();
+
+                            final int resolvedIcon = selectedIcon;
+                            final String finalEventName = eventName;
+                            OpenAIDescriptionGenerator.generateDescription(eventName, description -> {
+                                if (!isAdded()) {
+                                    positiveButton.setEnabled(true);
+                                    return;
+                                }
+
+                                Event event = new Event(finalEventName, description, resolvedIcon);
+                                event.setEventId(eventId);
+                                viewModel.update(event);
+
+                                if (getContext() != null) {
+                                    Toast.makeText(getContext(), getString(R.string.toast_event_updated, finalEventName), Toast.LENGTH_SHORT).show();
+                                }
+
+                                dialog.dismiss();
+                            });
+                        });
+                    });
                     dialog.show();
                 }
 

--- a/TimeTracker/app/src/main/java/com/cs446/group18/timetracker/utils/OpenAIDescriptionGenerator.java
+++ b/TimeTracker/app/src/main/java/com/cs446/group18/timetracker/utils/OpenAIDescriptionGenerator.java
@@ -1,0 +1,164 @@
+package com.cs446.group18.timetracker.utils;
+
+import android.os.AsyncTask;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+
+import com.cs446.group18.timetracker.BuildConfig;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+public class OpenAIDescriptionGenerator {
+
+    public interface DescriptionCallback {
+        void onResult(@NonNull String description);
+    }
+
+    public static void generateDescription(@NonNull String eventType,
+                                           @NonNull DescriptionCallback callback) {
+        new GenerateDescriptionTask(eventType, callback).execute();
+    }
+
+    private static class GenerateDescriptionTask extends AsyncTask<Void, Void, String> {
+        private final String eventType;
+        private final DescriptionCallback callback;
+
+        private GenerateDescriptionTask(String eventType, DescriptionCallback callback) {
+            this.eventType = eventType;
+            this.callback = callback;
+        }
+
+        @Override
+        protected String doInBackground(Void... voids) {
+            String apiKey = BuildConfig.OPENAI_API_KEY;
+            if (TextUtils.isEmpty(apiKey) || "null".equalsIgnoreCase(apiKey)) {
+                return buildFallbackDescription();
+            }
+
+            HttpURLConnection connection = null;
+            try {
+                URL url = new URL("https://api.openai.com/v1/chat/completions");
+                connection = (HttpURLConnection) url.openConnection();
+                connection.setRequestMethod("POST");
+                connection.setRequestProperty("Content-Type", "application/json");
+                connection.setRequestProperty("Authorization", "Bearer " + apiKey);
+                connection.setConnectTimeout(15000);
+                connection.setReadTimeout(15000);
+                connection.setDoOutput(true);
+
+                JSONObject payload = buildRequestPayload();
+
+                OutputStream outputStream = connection.getOutputStream();
+                BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
+                writer.write(payload.toString());
+                writer.flush();
+                writer.close();
+                outputStream.close();
+
+                int responseCode = connection.getResponseCode();
+                InputStream responseStream = responseCode >= HttpURLConnection.HTTP_OK
+                        && responseCode < HttpURLConnection.HTTP_MULT_CHOICE
+                        ? connection.getInputStream() : connection.getErrorStream();
+
+                if (responseStream == null) {
+                    return buildFallbackDescription();
+                }
+
+                BufferedReader reader = new BufferedReader(new InputStreamReader(responseStream, StandardCharsets.UTF_8));
+                StringBuilder responseBuilder = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    responseBuilder.append(line);
+                }
+                reader.close();
+
+                return parseResponse(responseBuilder.toString());
+            } catch (IOException | JSONException e) {
+                e.printStackTrace();
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
+            }
+            return buildFallbackDescription();
+        }
+
+        @Override
+        protected void onPostExecute(String description) {
+            String finalDescription = TextUtils.isEmpty(description)
+                    ? buildFallbackDescription()
+                    : description;
+            callback.onResult(finalDescription);
+        }
+
+        private JSONObject buildRequestPayload() throws JSONException {
+            JSONObject payload = new JSONObject();
+            payload.put("model", "gpt-3.5-turbo");
+
+            JSONArray messages = new JSONArray();
+
+            JSONObject systemMessage = new JSONObject();
+            systemMessage.put("role", "system");
+            systemMessage.put("content", "You create concise, friendly descriptions for events in a personal time tracker.");
+            messages.put(systemMessage);
+
+            JSONObject userMessage = new JSONObject();
+            userMessage.put("role", "user");
+            userMessage.put("content", String.format(Locale.US,
+                    "Write a short description (maximum one sentence) for the time tracking event type \"%s\".",
+                    eventType));
+            messages.put(userMessage);
+
+            payload.put("messages", messages);
+            payload.put("max_tokens", 60);
+            payload.put("temperature", 0.7);
+
+            return payload;
+        }
+
+        private String parseResponse(String rawResponse) throws JSONException {
+            if (TextUtils.isEmpty(rawResponse)) {
+                return buildFallbackDescription();
+            }
+
+            JSONObject response = new JSONObject(rawResponse);
+            JSONArray choices = response.optJSONArray("choices");
+            if (choices != null && choices.length() > 0) {
+                JSONObject firstChoice = choices.optJSONObject(0);
+                if (firstChoice != null) {
+                    JSONObject message = firstChoice.optJSONObject("message");
+                    if (message != null) {
+                        String content = message.optString("content", "").trim();
+                        if (!TextUtils.isEmpty(content)) {
+                            return content.replaceAll("\\s+", " ").trim();
+                        }
+                    }
+                    String legacyContent = firstChoice.optString("text", "").trim();
+                    if (!TextUtils.isEmpty(legacyContent)) {
+                        return legacyContent.replaceAll("\\s+", " ").trim();
+                    }
+                }
+            }
+            return buildFallbackDescription();
+        }
+
+        private String buildFallbackDescription() {
+            return String.format(Locale.US, "Time dedicated to %s.", eventType);
+        }
+    }
+}

--- a/TimeTracker/app/src/main/res/layout/prompt_add_event.xml
+++ b/TimeTracker/app/src/main/res/layout/prompt_add_event.xml
@@ -32,15 +32,15 @@
         android:layout_marginRight="10dp"
         android:text="Event Description"/>
 
-    <EditText
-        android:id="@+id/event_description"
+    <TextView
+        android:id="@+id/prompt_text_event_description_hint"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="10dp"
         android:layout_marginTop="5dp"
         android:layout_marginRight="10dp"
         android:layout_marginBottom="4dp"
-        android:inputType="text" />
+        android:text="@string/prompt_generated_description_notice"/>
 
     <TextView
         android:id="@+id/prompt_text_event_icon"

--- a/TimeTracker/app/src/main/res/values/strings.xml
+++ b/TimeTracker/app/src/main/res/values/strings.xml
@@ -17,4 +17,9 @@
     <string name="timeline_start">Timeline start</string>
     <string name="timeline_no_events">No events found</string>
     <string name="no_data">No data availble.</string>
+    <string name="prompt_generated_description_notice">A short description will be generated automatically based on the selected event type.</string>
+    <string name="toast_generating_event_description">Generating description…</string>
+    <string name="toast_event_created">Add new event: %1$s</string>
+    <string name="toast_event_updated">Event updated: %1$s</string>
+    <string name="error_event_name_required">Please enter an event name.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add an OpenAI-backed description generator and call it when creating or editing events
- update the add/edit dialog to explain that descriptions are generated automatically and default to a sane icon when none is chosen
- expose the OpenAI API key via BuildConfig and ignore the local properties file in git

## Testing
- sh gradlew test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d3b9cb05d883268d8b37c8b9f52705