### PR TITLE
Add Settings navigation entry

### DIFF
--- a/TimeTracker/app/src/main/java/com/cs446/group18/timetracker/ui/SettingsFragment.java
+++ b/TimeTracker/app/src/main/java/com/cs446/group18/timetracker/ui/SettingsFragment.java
@@ -1,0 +1,26 @@
+package com.cs446.group18.timetracker.ui;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.cs446.group18.timetracker.R;
+
+public class SettingsFragment extends Fragment {
+
+    public SettingsFragment() {
+        // Required empty public constructor
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_settings, container, false);
+    }
+}

--- a/TimeTracker/app/src/main/res/layout/fragment_settings.xml
+++ b/TimeTracker/app/src/main/res/layout/fragment_settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/settings_placeholder_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/title_settings"
+        android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+</FrameLayout>

--- a/TimeTracker/app/src/main/res/menu/menu_navigation.xml
+++ b/TimeTracker/app/src/main/res/menu/menu_navigation.xml
@@ -15,6 +15,10 @@
         android:title="Reports"/>
 
     <item
+        android:id="@+id/settings_fragment"
+        android:title="@string/title_settings"/>
+
+    <item
         android:id="@+id/read_tag_activity"
         android:title="Read Tag"/>
 

--- a/TimeTracker/app/src/main/res/navigation/nav_bar.xml
+++ b/TimeTracker/app/src/main/res/navigation/nav_bar.xml
@@ -28,6 +28,12 @@
         android:label="Reports"
         tools:layout="@layout/fragment_report" />
 
+    <fragment
+        android:id="@+id/settings_fragment"
+        android:name="com.cs446.group18.timetracker.ui.SettingsFragment"
+        android:label="@string/title_settings"
+        tools:layout="@layout/fragment_settings" />
+
     <activity
         android:id="@+id/read_tag_activity"
         android:name="com.cs446.group18.timetracker.ui.NFCReadActivity"

--- a/TimeTracker/app/src/main/res/values-night/strings.xml
+++ b/TimeTracker/app/src/main/res/values-night/strings.xml
@@ -5,5 +5,6 @@
     <string name="text_turn_on_nfc">This example can\'t be used without NFC enabled. Please turn on NFC in the Settings and then use the back button to return to this app.</string>
     <string name="text_update_settings">Update Settings</string>
     <!-- TODO: Remove or change this placeholder text -->
+    <string name="title_settings">Settings</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>

--- a/TimeTracker/app/src/main/res/values/strings.xml
+++ b/TimeTracker/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="tab_yearly">Yearly</string>
     <string name="title_heatmap">Heatmap</string>
     <string name="share_btn_text">Share</string>
+    <string name="title_settings">Settings</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="timeline_start">Timeline start</string>
     <string name="timeline_no_events">No events found</string>


### PR DESCRIPTION
## Summary
- add a simple `SettingsFragment` and placeholder layout
- wire the new fragment into the navigation graph and drawer menu
- centralize the Settings label as a shared string resource

## Testing
- ./gradlew lint *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d3ab91fe2883268d36b4307e8db659